### PR TITLE
Issue 6 logger aware decorators

### DIFF
--- a/Tests/SingleMessageLogger.php
+++ b/Tests/SingleMessageLogger.php
@@ -1,0 +1,19 @@
+<?php
+namespace CristianPontes\ZohoCRMClient\Tests;
+
+use Psr\Log\AbstractLogger;
+
+class SingleMessageLogger extends AbstractLogger {
+
+    private $message = '';
+
+    public function log($level, $message, array $context = array())
+    {
+        $this->message = $message;
+    }
+
+    public function getLogs()
+    {
+        return $this->message;
+    }
+}

--- a/Tests/Transport/AbstractTransportDecoratorTest.php
+++ b/Tests/Transport/AbstractTransportDecoratorTest.php
@@ -1,0 +1,41 @@
+<?php
+namespace CristianPontes\ZohoCRMClient\Tests\Transport;
+
+use CristianPontes\ZohoCRMClient\Transport\MockLoggerAwareTransport;
+use CristianPontes\ZohoCRMClient\Tests\SingleMessageLogger;
+use CristianPontes\ZohoCRMClient\Transport\AbstractTransportDecorator;
+
+class AbstractTransportDecoratorTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var mockDecorator */
+    private $decorator;
+
+    public function testSetLogger()
+    {
+        $logger = new SingleMessageLogger();
+        $this->decorator->setLogger($logger);
+
+        $module = 'Accounts';
+        $method = 'getFields';
+        $paramList = array();
+
+        $this->decorator->call($module, $method, $paramList);
+
+        $logs = $logger->getLogs();
+        $this->assertEquals('Accounts/getFields', $logs);
+    }
+
+    protected function setUp()
+    {
+        $transport = new MockLoggerAwareTransport();
+        $this->decorator = new mockDecorator($transport);
+    }
+}
+
+class mockDecorator extends AbstractTransportDecorator
+{
+    public function call($module, $method, array $paramList)
+    {
+        return $this->transport->call($module, $method, $paramList);
+    }
+}

--- a/Tests/ZohoCRMClientTest.php
+++ b/Tests/ZohoCRMClientTest.php
@@ -4,7 +4,7 @@ namespace CristianPontes\ZohoCRMClient\Tests;
 use CristianPontes\ZohoCRMClient\Request\GetRecords;
 use CristianPontes\ZohoCRMClient\Transport\MockLoggerAwareTransport;
 use CristianPontes\ZohoCRMClient\ZohoCRMClient;
-use Psr\Log\AbstractLogger;
+use CristianPontes\ZohoCRMClient\Tests\SingleMessageLogger;
 
 class ZohoCRMClientTest extends \PHPUnit_Framework_TestCase
 {
@@ -91,21 +91,6 @@ class ZohoCRMClientTest extends \PHPUnit_Framework_TestCase
     {
         $this->transport = new MockLoggerAwareTransport();
         $this->client = new mockZohoCRMClient('Leads', $this->transport);
-    }
-}
-
-class SingleMessageLogger extends AbstractLogger {
-
-    private $message = '';
-
-    public function log($level, $message, array $context = array())
-    {
-        $this->message = $message;
-    }
-
-    public function getLogs()
-    {
-        return $this->message;
     }
 }
 

--- a/Transport/AbstractTransportDecorator.php
+++ b/Transport/AbstractTransportDecorator.php
@@ -1,0 +1,38 @@
+<?php
+namespace CristianPontes\ZohoCRMClient\Transport;
+
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Base abstract logger-aware Transport Decorator
+ */
+abstract class AbstractTransportDecorator implements Transport, LoggerAwareInterface
+{
+    protected $transport;
+
+    function __construct(Transport $transport)
+    {
+        $this->transport = $transport;
+    }
+
+    /**
+     * @param string $module
+     * @param string $method
+     * @param array $paramList
+     * @return array
+     */
+    abstract public function call($module, $method, array $paramList);
+
+    /**
+     * Sets a logger instance on the transport
+     *
+     * @param LoggerInterface $logger
+     */
+    public function setLogger(LoggerInterface $logger)
+    {
+        if ($this->transport instanceof LoggerAwareInterface) {
+            $this->transport->setLogger($logger);
+        }
+    }
+}

--- a/Transport/AuthenticationTokenTransportDecorator.php
+++ b/Transport/AuthenticationTokenTransportDecorator.php
@@ -4,15 +4,14 @@ namespace CristianPontes\ZohoCRMClient\Transport;
 /**
  * Transport Decorator that transparently adds the authtoken param and scope param
  */
-class AuthenticationTokenTransportDecorator implements Transport
+class AuthenticationTokenTransportDecorator extends AbstractTransportDecorator
 {
     private $authToken;
-    private $transport;
 
     function __construct($authToken, Transport $transport)
     {
         $this->authToken = $authToken;
-        $this->transport = $transport;
+        parent::__construct($transport);
     }
 
     public function call($module, $method, array $paramList)

--- a/Transport/XmlDataTransportDecorator.php
+++ b/Transport/XmlDataTransportDecorator.php
@@ -10,10 +10,8 @@ use SimpleXMLElement;
 /**
  * XmlDataTransportDecorator handles the XML communication with Zoho
  */
-class XmlDataTransportDecorator implements Transport
+class XmlDataTransportDecorator extends AbstractTransportDecorator
 {
-    /** @var Transport */
-    private $transport;
     /** @var string */
     private $module;
     /** @var string */
@@ -27,7 +25,7 @@ class XmlDataTransportDecorator implements Transport
      */
     public function __construct(Transport $transport)
     {
-        $this->transport = $transport;
+        parent::__construct($transport);
     }
 
     /**


### PR DESCRIPTION
There could be different ways how to implement LoggerAwareInterface for decorators.
I suggest to introduce a base class for decorators - AbstractTransportDecorator.
XmlDataTransportDecorator and AuthenticationTokenTransportDecorator are extended from it.

AbstractTransportDecorator implements LoggerAwareInterface and declare implementing Transport interface.

Another implementation for base class - make it not abstract, with default implementation for call() method  like:
```
    public function call($module, $method, array $paramList)
    {
        return $this->transport->call($module, $method, $paramList);
    }
```

@cristianpontes  What do think? 