### PR TITLE
Add support for triggering an Assignment Rule

### DIFF
--- a/Request/InsertRecords.php
+++ b/Request/InsertRecords.php
@@ -52,6 +52,16 @@ class InsertRecords extends AbstractRequest
     }
 
     /**
+     * @param int $ruleId
+     * @return InsertRecords
+     */
+    public function triggerAssignmentRule($ruleId)
+    {
+        $this->request->setParam('larid', $ruleId);
+        return $this;
+    }
+
+    /**
      * @return InsertRecords
      */
     public function onDuplicateUpdate()

--- a/Tests/Request/InsertRecordsTest.php
+++ b/Tests/Request/InsertRecordsTest.php
@@ -39,6 +39,13 @@ class InsertRecordsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('true', $this->request->getParam('wfTrigger'));
     }
 
+    public function testTriggerAssignmentRule()
+    {
+        $ruleId = 99001321231213;
+        $this->insertRecords->triggerAssignmentRule($ruleId);
+        $this->assertEquals($ruleId, $this->request->getParam('larid'));
+    }
+
     public function testOnDuplicate()
     {
         $this->insertRecords->onDuplicateUpdate();
@@ -64,4 +71,3 @@ class InsertRecordsTest extends \PHPUnit_Framework_TestCase
         $this->insertRecords = new Request\InsertRecords($this->request);
     }
 }
- 


### PR DESCRIPTION
It doesn't appear to be documented anywhere, but I learned from Zoho
support that if you pass a `larid` param with the ID of a Zoho
Assignment Rule as a parameter, that assignment rule will be kicked off
in Zoho when you insert records via the API. I've only tested this out
with inserting Leads. Mileage may vary in other types of cases. A far as I know, this also only works with a single rule. I didn't try passing more than one.

Thanks!